### PR TITLE
Reduce View element count for border clipping scenarios  (#2340)

### DIFF
--- a/RNWCPP/ReactUWP/Views/ViewPanel.cpp
+++ b/RNWCPP/ReactUWP/Views/ViewPanel.cpp
@@ -181,7 +181,7 @@ winrt::Size ViewPanel::ArrangeOverride(winrt::Size finalSize)
     double childWidth = 0.0;
 
     // A Border or inner ViewPanel should take up the same space as this panel
-    if ((child == m_border) || (child == m_innerElement))
+    if (child == m_border)
     {
       childWidth = finalSize.Width;
       childHeight = finalSize.Height;
@@ -215,75 +215,28 @@ winrt::Size ViewPanel::ArrangeOverride(winrt::Size finalSize)
 
 void ViewPanel::InsertAt(uint32_t const index, winrt::UIElement const &value) const
 {
-  auto innerPanel = GetInnerPanel();
-  if (innerPanel != nullptr)
-    innerPanel->InsertAt(index, value);
-  else
-    Children().InsertAt(index, value);
+  Children().InsertAt(index, value);
 }
 
 void ViewPanel::RemoveAt(uint32_t const index) const
 {
-  auto innerPanel = GetInnerPanel();
-  if (innerPanel != nullptr)
-    innerPanel->RemoveAt(index);
-  else
-    Children().RemoveAt(index);
+  Children().RemoveAt(index);
 }
 
 void ViewPanel::Remove(winrt::UIElement element) const
 {
-  auto innerPanel = GetInnerPanel();
-  if (innerPanel != nullptr)
-  {
-    innerPanel->Remove(element);
-  }
-  else
-  {
-    uint32_t index;
+  uint32_t index;
 
-    if (Children().IndexOf(element, index))
-      Children().RemoveAt(index);
-  }
+  if (Children().IndexOf(element, index))
+    Children().RemoveAt(index);
 }
 
 void ViewPanel::Clear() const
 {
-  auto innerPanel = GetInnerPanel();
-  if (innerPanel != nullptr)
-    innerPanel->Clear();
-  else
-    Children().Clear();
+  Children().Clear();
 }
 
-winrt::UIElement ViewPanel::GetAt(uint32_t const index) const
-{
-  auto innerPanel = GetInnerPanel();
-  if (innerPanel != nullptr)
-    return innerPanel->GetAt(index);
-  else
-    return Children().GetAt(index);
-}
-
-uint32_t ViewPanel::Size() const
-{
-  auto innerPanel = GetInnerPanel();
-  if (innerPanel != nullptr)
-  {
-    return innerPanel->Size();
-  }
-  else
-  {
-    auto size = Children().Size();
-
-    if (m_border != nullptr)
-      size -= 1;
-
-    return size;
-  }
-}
-
-void ViewPanel::Background(winrt::Brush const &value)
+void ViewPanel::Background(winrt::Brush const& value)
 {
   SetValue(BackgroundProperty(), winrt::box_value(value));
 }
@@ -308,40 +261,6 @@ void ViewPanel::ClipChildren(bool value)
   SetValue(ClipChildrenProperty(), winrt::box_value(value));
 }
 
-void ViewPanel::EnsureBorder()
-{
-  if (m_border == nullptr)
-  {
-    m_border = winrt::Border();
-    Children().Append(m_border);
-  }
-}
-
-void ViewPanel::EnsureInnerPanel()
-{
-  // ASSERT: Need to have a Border to put the ViewPanel into
-  assert(m_border != nullptr);
-
-  if (m_innerElement == nullptr)
-  {
-    auto innerPanel = ViewPanel::Create();
-    m_innerElement = innerPanel.try_as<winrt::UIElement>();
-
-    // If there are any children other than our own border then we need to transfer them to the inner panel
-    for (uint32_t i = Children().Size(); i > 0; --i)
-    {
-      auto child = Children().GetAt(i - 1);
-      if (child != m_border)
-      {
-        Children().RemoveAt(i - 1);
-        innerPanel->InsertAt(0, child);
-      }
-    }
-
-    m_border.Child(m_innerElement);
-  }
-}
-
 void ViewPanel::FinalizeProperties()
 {
   if (!m_propertiesChanged)
@@ -349,20 +268,17 @@ void ViewPanel::FinalizeProperties()
 
   // There are 3 different solutions
   //
-  //  A) Have Border with Inner Panel child that contains real children
-  //      >> border and background properties go on the Border
-  //      ** This solution only used when there is a corner radius
-  //  B) Have Border with no child and this Panel contains the Border and the real children
-  //      >> border properties go on Border, background goes on this Panel
-  //      ** This solution used when there are border properties but no corner radius
-  //  C) No Border and real children contained by this Panel
-  //      >> background goes on this Panel
-  //      ** This solution used when there are no border properties or corner radius
+  //  A) No Border
+  //      -- No need for any border properties so just contain real children
+  //      >> Background applied to ViewPanel
   //
-  // What we need to know:
-  //  1. Do we need an inner panel? Only if we have a corner radius and need clipping.
-  //  2. Do we need a Border? NOTE: Includes any time we need an inner panel!
-  //  3. Where do we apply the background? (implied by #1)
+  //  B) Inner Border (child of this panel along with real children)
+  //      -- Border created and made a child of this panel, alongside standard children
+  //      >> Border* properties applied to Border, Background applied to ViewPanel
+  //
+  //  C) Outer Border
+  //      -- Border created but handed out to view manager to make parent of this ViewPanel
+  //      >> Border* properties and Background applied to Border
 
   const auto unsetValue = winrt::DependencyProperty::UnsetValue();
 
@@ -372,14 +288,41 @@ void ViewPanel::FinalizeProperties()
   bool hasCornerRadius = ReadLocalValue(CornerRadiusProperty()) != unsetValue;
   bool displayBorder = hasBorderBrush && hasBorderThickness;
 
-  bool needInnerPanel = hasCornerRadius && (ClipChildren() || !displayBorder);
-  bool needBorder = needInnerPanel || hasCornerRadius || (hasBorderThickness && hasBorderBrush);
+  // Determine which scenario our current properties have put us into
+  enum Scenario { OuterBorder, InnerBorder, NoBorder } scenario;
+  if (hasCornerRadius)
+  {
+    scenario = Scenario::OuterBorder;
+    m_hasOuterBorder = true;
+  }
+  else if (!displayBorder)
+  {
+    scenario = Scenario::NoBorder;
+    m_hasOuterBorder = false;
+  }
+  else if (ClipChildren())
+  {
+    scenario = Scenario::OuterBorder;
+    m_hasOuterBorder = true;
+  }
+  else
+  {
+    scenario = Scenario::InnerBorder;
+    m_hasOuterBorder = false;
+  }
 
   // Border element
-  if (needBorder)
+  if (scenario != Scenario::NoBorder)
   {
-    // Ensure Border is created and set properties
-    EnsureBorder();
+    // Ensure Border is created
+    if (m_border == nullptr)
+    {
+      m_border = winrt::Border();
+
+      // Add border as the top child if using as inner border
+      if (scenario == Scenario::InnerBorder)
+        Children().Append(m_border);
+    }
 
     // TODO: Can Binding be used here?
     if (hasBorderBrush)
@@ -404,35 +347,22 @@ void ViewPanel::FinalizeProperties()
     m_border = nullptr;
   }
 
-  // Inner ViewPanel element
-  if (needInnerPanel)
+  if (scenario == Scenario::OuterBorder)
   {
-    EnsureInnerPanel();
-  }
-  else if (m_innerElement != nullptr)
-  {
-    Remove(m_innerElement);
-    m_innerElement = nullptr;
-  }
-
-  // Background property: On Border if there's an inner Panel, on this Panel otherwise
-  if (needInnerPanel)
-  {
-    // Remove any background set on this Panel
-    Super::ClearValue(winrt::Panel::BackgroundProperty());
-
-    // Set any background on the Border
     if (hasBackground)
       m_border.Background(Background());
     else
       m_border.ClearValue(winrt::Border::BackgroundProperty());
+
+    ClearValue(winrt::Panel::BackgroundProperty());
   }
   else
   {
-    // Remove any background set on the Border and set it on this Panel
-    if (m_border != nullptr)
-      m_border.ClearValue(winrt::Border::BackgroundProperty());
-
+    // Set any background on this Panel
+    if (hasBackground)
+      SetValue(winrt::Panel::BackgroundProperty(), Background());
+    else
+      ClearValue(winrt::Panel::BackgroundProperty());
     // Set any background on this Panel
     if (hasBackground)
       SetValue(winrt::Panel::BackgroundProperty(), Background());
@@ -445,12 +375,18 @@ void ViewPanel::FinalizeProperties()
   m_propertiesChanged = false;
 }
 
+winrt::Border ViewPanel::GetOuterBorder()
+{
+  if (m_hasOuterBorder && (m_border != nullptr))
+    return m_border;
+  else
+    return winrt::Border(nullptr);
+}
+
 void ViewPanel::UpdateClip()
 {
-  // Clipping is only applied to the outer panel. If the inner Panel is used it implies that
-  //  clipping will happen and be handled by the Border element.
-
-  if (ClipChildren())
+  // When an outer Border is used it will handle the clipping, otherwise this panel must do so
+  if (!m_hasOuterBorder && ClipChildren())
   {
     winrt::RectangleGeometry clipGeometry;
     clipGeometry.Rect(winrt::Rect(0, 0, static_cast<float>(ActualWidth()), static_cast<float>(ActualHeight())));
@@ -461,13 +397,6 @@ void ViewPanel::UpdateClip()
   {
     Clip(nullptr);
   }
-}
-
-ViewPanel *ViewPanel::GetInnerPanel() const
-{
-  return (m_innerElement != nullptr)
-             ? m_innerElement.try_as<ViewPanel>().get()
-             : nullptr;
 }
 
 } // namespace uwp

--- a/RNWCPP/ReactUWP/Views/ViewPanel.h
+++ b/RNWCPP/ReactUWP/Views/ViewPanel.h
@@ -31,10 +31,8 @@ public:
   void RemoveAt(uint32_t const index) const;
   void Clear() const;
 
-  winrt::Windows::UI::Xaml::UIElement GetAt(uint32_t const index) const;
-  uint32_t Size() const;
-
   void FinalizeProperties();
+  winrt::Windows::UI::Xaml::Controls::Border GetOuterBorder();
 
   // Public Properties
   winrt::Windows::UI::Xaml::Media::Brush Background() { return GetValue(BackgroundProperty()).try_as<winrt::Windows::UI::Xaml::Media::Brush>(); }
@@ -70,11 +68,6 @@ public:
   static double GetLeft(winrt::Windows::UI::Xaml::UIElement& element) { return winrt::unbox_value<double>(element.GetValue(LeftProperty())); }
 
 private:
-  // Managing the Border & Background Elements
-  void EnsureBorder();
-  void EnsureInnerPanel();
-  ViewPanel* GetInnerPanel() const;
-
   void Remove(winrt::Windows::UI::Xaml::UIElement element) const;
 
   void UpdateClip();
@@ -86,7 +79,7 @@ private:
 
   // Child Elements
   winrt::Windows::UI::Xaml::Controls::Border m_border { nullptr };
-  winrt::Windows::UI::Xaml::UIElement m_innerElement { nullptr };
+  bool m_hasOuterBorder;
 
 private:
   static void VisualPropertyChanged(winrt::Windows::UI::Xaml::DependencyObject sender, winrt::Windows::UI::Xaml::DependencyPropertyChangedEventArgs e);

--- a/RNWCPP/ReactUWP/Views/ViewViewManager.h
+++ b/RNWCPP/ReactUWP/Views/ViewViewManager.h
@@ -8,6 +8,7 @@
 namespace react { namespace uwp {
 
 class ViewShadowNode;
+struct ViewPanel;
 
 class ViewViewManager : public FrameworkElementViewManager
 {
@@ -28,8 +29,7 @@ public:
 
 protected:
   XamlView CreateViewCore(int64_t tag) override;
-  void ReplaceView(ViewShadowNode* viewShadowNode, bool useControl);
-  void TransferProperties(XamlView oldView, XamlView newView) override;
+  void TryUpdateView(ViewShadowNode* viewShadowNode, ViewPanel* pPanel, bool useControl);
 
 private:
   void DispatchEvent(int64_t viewTag, std::string eventName, folly::dynamic&& eventData);

--- a/RNWCPP/Universal.SampleApp/view.uwp.js
+++ b/RNWCPP/Universal.SampleApp/view.uwp.js
@@ -1,0 +1,141 @@
+/**
+ * Sample React Native App
+ * https://github.com/facebook/react-native
+ * @flow
+ */
+
+import React, { Component } from 'react';
+import {
+  ActivityIndicator,
+  AppRegistry,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {
+  CheckBox,
+  DatePicker,
+  Picker,
+} from 'react-native-windows';
+
+export default class Bootstrap extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { focusable: true, hasBorder: true, radius: true };
+  }
+
+  render() {
+    styles = StyleSheet.create({
+      noBorder: {
+        margin: 20,
+        padding: 15,
+        backgroundColor: 'orange',
+        borderRadius: 0,
+      },
+      innerBorder: {
+        margin: 20,
+        padding: 15,
+        backgroundColor: 'lime',
+        borderColor: 'navy',
+        borderWidth: 1,
+        borderRadius: 0,
+      },
+      outerBorder: {
+        margin: 20,
+        padding: 15,
+        backgroundColor: 'pink',
+        borderColor: 'crimson',
+        borderWidth: 1,
+        borderRadius: 10,
+      },
+      radial: {
+        margin: 20,
+        padding: 15,
+        backgroundColor: 'magenta',
+        borderRadius: 10,
+      },
+    });
+
+    return (
+      <View style={{ flex: 1, flexDirection: 'column', alignSelf: 'center', alignItems: 'center', justifyContent: 'center', width: 250, backgroundColor: 'azure', paddingHorizontal: 20 }}>
+
+        <View style={{ flexDirection: 'row', alignSelf: 'flex-start' }}>
+          <CheckBox
+            onValueChange={value => this.setState({ focusable: value })}
+            checked={this.state.focusable} />
+          <Text>acceptsKeyboardFocus</Text>
+        </View>
+
+        <View style={{ flexDirection: 'row', alignSelf: 'flex-start' }}>
+          <CheckBox
+            onValueChange={value => this.setState({ hasBorder: value })}
+            checked={this.state.hasBorder} />
+          <Text>hasBorder</Text>
+        </View>
+
+        <View style={{ flexDirection: 'row', alignSelf: 'flex-start' }}>
+          <CheckBox
+            onValueChange={value => this.setState({ radius: value })}
+            checked={this.state.radius} />
+          <Text>hasRadius</Text>
+        </View>
+
+        <View enableFocusRing={true} acceptsKeyboardFocus={this.state.focusable ? true : false}
+            style={
+              !this.state.hasBorder
+                ? (this.state.radius ? styles.radial : styles.noBorder)
+                : (this.state.radius ? styles.outerBorder : styles.innerBorder)
+            }>
+          <Text>The text!</Text>
+        </View>
+      </View>
+    );
+  }
+
+  fullrender() {
+    return (
+      <View accessible={true} style={{ flex: 1, flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 15 }}>
+          <CheckBox
+            onValueChange={value => this.setState({ focusable: value })}
+            checked={this.state.focusable} />
+          <Text>acceptsKeyboardFocus</Text>
+        </View>
+        <View enableFocusRing={true} acceptsKeyboardFocus={this.state.focusable ? true : false} style={{ padding: 15, backgroundColor: 'lime', borderColor: 'navy', borderWidth: 2, borderRadius: 0 }}>
+          <Text>TEXT</Text>
+        </View>
+        <View style={{ backgroundColor: 'orange', margin: 5 }}>
+          <View style={{ height: 25, width: 75, backgroundColor: 'lime', padding: this.state.padding, margin: this.state.margin }} />
+        </View>
+        <View style={{ backgroundColor: 'orange', margin: 5 }}>
+          <DatePicker style={{ backgroundColor: 'lime', padding: this.state.padding, margin: this.state.margin }} />
+        </View>
+        <View style={{ backgroundColor: 'orange', margin: 5 }}>
+          <Picker style={{ backgroundColor: 'lime', padding: this.state.padding, margin: this.state.margin }} />
+        </View>
+        <View style={{ backgroundColor: 'orange', margin: 5 }}>
+          <Switch style={{ backgroundColor: 'lime', padding: this.state.padding, margin: this.state.margin }} />
+        </View>
+        <View style={{ backgroundColor: 'orange', margin: 5 }}>
+          <CheckBox style={{ backgroundColor: 'lime', padding: this.state.padding, margin: this.state.margin }} />
+        </View>
+        <View style={{ backgroundColor: 'orange', margin: 5 }}>
+          <TextInput style={{ backgroundColor: 'lime', padding: this.state.padding, margin: this.state.margin }}
+            placeholder={"type something ..."}
+            placeholderTextColor={"maroon"}
+          />
+        </View>
+        <View style={{ backgroundColor: 'orange', margin: 5 }}>
+          <Text style={{ backgroundColor: 'lime', padding: this.state.padding, margin: this.state.margin }}>
+            type nothing ...
+          </Text>
+        </View>
+      </View>
+    );
+  }
+};
+
+AppRegistry.registerComponent('Bootstrap', () => Bootstrap);


### PR DESCRIPTION
* Reduce and rationalize some header file includes related to ShadowNodeBase & ViewManagerBase. Reduces dependencies for build.

* Checkpoint.

* Remove debugging code. Update view sample to drive three scenarios.

* Remove TODO NOW comment.